### PR TITLE
Better topological sort, second try

### DIFF
--- a/src/UHF/Data/ANFIR.hs
+++ b/src/UHF/Data/ANFIR.hs
@@ -5,8 +5,7 @@ module UHF.Data.ANFIR
     , BindingKey
     , ParamKey
 
-    , BindingChunk(..)
-    , chunk_bindings
+    , TopologicalSortStatus (..)
     , BindingGroup (..)
     , Binding (..)
 
@@ -52,10 +51,8 @@ data CU = CU { cu_main_function :: Maybe BindingKey, cu_bindings :: BindingGroup
 
 data Param = Param ID.VariableID (Maybe Type.Type) deriving Show
 
-data BindingChunk
-    = SingleBinding BindingKey
-    | MutuallyRecursiveBindings [BindingKey] deriving Show
-data BindingGroup = BindingGroup { binding_group_chunks :: [BindingChunk] } deriving Show
+data TopologicalSortStatus = TopologicallySorted | HasLoops deriving Show
+data BindingGroup = BindingGroup { binding_group_status :: TopologicalSortStatus, binding_group_bindings :: [BindingKey] } deriving Show
 data Binding = Binding { binding_initializer :: Expr } deriving Show
 
 data ID
@@ -157,7 +154,3 @@ binding_type :: Binding -> Maybe Type.Type
 binding_type = expr_type . binding_initializer
 binding_id :: Binding -> ID
 binding_id = expr_id . binding_initializer
-
-chunk_bindings :: BindingChunk -> [BindingKey]
-chunk_bindings (SingleBinding b) = [b]
-chunk_bindings (MutuallyRecursiveBindings bs) = bs

--- a/src/UHF/Data/ANFIR/PP.hs
+++ b/src/UHF/Data/ANFIR/PP.hs
@@ -55,13 +55,9 @@ refer_binding :: ANFIR.BindingKey -> IRReader PP.Token
 refer_binding key = ANFIR.binding_id <$> get_binding key >>= \ id -> pure (PP.String (ANFIR.stringify_id id))
 
 define_binding_group_flat :: ANFIR.BindingGroup -> IRReader [PP.Token]
-define_binding_group_flat (ANFIR.BindingGroup chunks) = mapM define_chunk chunks
+define_binding_group_flat (ANFIR.BindingGroup _ bindings) = mapM define_binding bindings
 define_binding_group :: ANFIR.BindingGroup -> IRReader PP.Token
-define_binding_group (ANFIR.BindingGroup chunks) = mapM define_chunk chunks >>= \ chunks -> pure (PP.braced_block chunks)
-
-define_chunk :: ANFIR.BindingChunk -> IRReader PP.Token
-define_chunk (ANFIR.SingleBinding bk) = define_binding bk
-define_chunk (ANFIR.MutuallyRecursiveBindings bindings) = mapM define_binding bindings >>= \ bindings -> pure (PP.List ["mutually recursive ", PP.braced_block bindings])
+define_binding_group (ANFIR.BindingGroup _ bindings) = mapM define_binding bindings >>= \ bindings -> pure (PP.braced_block bindings)
 
 define_binding :: ANFIR.BindingKey -> IRReader PP.Token
 define_binding key =

--- a/src/UHF/Driver.hs
+++ b/src/UHF/Driver.hs
@@ -51,8 +51,8 @@ type InfixGroupedSIR = SIR.SIR (Maybe (SIR.Decl TypeSolver.Type), Maybe (SIR.Dec
 type TypedSIR = SIR.SIR (Maybe (SIR.Decl IR.Type.Type), Maybe (SIR.Decl IR.Type.Type), Maybe IR.Type.Type, Maybe SIR.BoundValue, Maybe SIR.BoundValue, Maybe IR.Type.ADT.VariantIndex, Maybe IR.Type.ADT.VariantIndex, Maybe IR.Type.Type, Void)
 type RIR = RIR.RIR
 type ANFIR = ANFIR.ANFIR
-type BackendIR = BackendIR.BackendIR (Maybe IR.Type.Type) ()
-type NoPoisonIR = BackendIR.BackendIR IR.Type.Type Void
+type BackendIR = BackendIR.BackendIR (Either BackendIR.HasLoops BackendIR.TopologicallySorted) (Maybe IR.Type.Type) ()
+type NoPoisonIR = BackendIR.BackendIR BackendIR.TopologicallySorted IR.Type.Type Void
 type TS = Text
 
 type WithDiagnosticsIO = Compiler.WithDiagnosticsT Diagnostic.Error Diagnostic.Warning IO

--- a/src/UHF/Parts/OptimizeANFIR/Utils.hs
+++ b/src/UHF/Parts/OptimizeANFIR/Utils.hs
@@ -12,10 +12,7 @@ iterate_over_bindings change (ANFIR.ANFIR adts type_synonyms vars bindings param
     where
         do_cu (ANFIR.CU _ group _ _) = do_group group
 
-        do_group (ANFIR.BindingGroup chunks) = mapM_ do_chunk chunks
-
-        do_chunk (ANFIR.SingleBinding b) = do_binding b
-        do_chunk (ANFIR.MutuallyRecursiveBindings b) = mapM_ do_binding b
+        do_group (ANFIR.BindingGroup _ bs) = mapM_ do_binding bs
 
         -- ideally would use modifyM but that is not in the transformers package of this stackage snapshot
         do_binding bk =

--- a/src/UHF/Parts/RemovePoison.hs
+++ b/src/UHF/Parts/RemovePoison.hs
@@ -7,20 +7,22 @@ import qualified UHF.Data.IR.Type as Type
 import qualified UHF.Data.IR.Type.ADT as Type.ADT
 import qualified UHF.Util.Arena as Arena
 
-type PoisonedBackendIR = BackendIR.BackendIR PoisonedType ()
+type PoisonedTopologicalSortStatus = Either BackendIR.HasLoops BackendIR.TopologicallySorted
+type PoisonedBackendIR = BackendIR.BackendIR PoisonedTopologicalSortStatus PoisonedType ()
 type PoisonedType = Maybe Type.Type
 type PoisonedADT = Type.ADT PoisonedType
 type PoisonedTypeSynonym = Type.TypeSynonym PoisonedType
-type PoisonedExpr = BackendIR.Expr PoisonedType ()
-type PoisonedBinding = BackendIR.Binding PoisonedType ()
+type PoisonedExpr = BackendIR.Expr PoisonedTopologicalSortStatus PoisonedType ()
+type PoisonedBinding = BackendIR.Binding PoisonedTopologicalSortStatus PoisonedType ()
 type PoisonedParam = BackendIR.Param PoisonedType
 
-type NoPoisonBackendIR = BackendIR.BackendIR NoPoisonType Void
+type NoPoisonTopologicalSortStatus = BackendIR.TopologicallySorted
+type NoPoisonBackendIR = BackendIR.BackendIR NoPoisonTopologicalSortStatus NoPoisonType Void
 type NoPoisonType = Type.Type
 type NoPoisonADT = Type.ADT NoPoisonType
 type NoPoisonTypeSynonym = Type.TypeSynonym NoPoisonType
-type NoPoisonExpr = BackendIR.Expr NoPoisonType Void
-type NoPoisonBinding = BackendIR.Binding NoPoisonType Void
+type NoPoisonExpr = BackendIR.Expr NoPoisonTopologicalSortStatus NoPoisonType Void
+type NoPoisonBinding = BackendIR.Binding NoPoisonTopologicalSortStatus NoPoisonType Void
 type NoPoisonParam = BackendIR.Param NoPoisonType
 
 remove_poison :: PoisonedBackendIR -> Maybe NoPoisonBackendIR
@@ -33,11 +35,11 @@ remove_poison (BackendIR.BackendIR adts type_synonyms type_vars bindings params 
         <*> Arena.transformM rp_param params
         <*> rp_cu cu
 
-rp_cu :: BackendIR.CU () -> Maybe (BackendIR.CU Void)
-rp_cu (BackendIR.CU (Right main_function) bindings adts type_synonyms) = Just (BackendIR.CU (Right main_function) bindings adts type_synonyms)
-rp_cu (BackendIR.CU (Left ()) _ _ _) = Nothing
-
 -- rp short for remove poison
+
+rp_cu :: BackendIR.CU PoisonedTopologicalSortStatus () -> Maybe (BackendIR.CU NoPoisonTopologicalSortStatus Void)
+rp_cu (BackendIR.CU (Right main_function) bindings adts type_synonyms) = BackendIR.CU (Right main_function) <$> rp_group bindings <*> pure adts <*> pure type_synonyms
+rp_cu (BackendIR.CU (Left ()) _ _ _) = Nothing
 
 rp_adt :: PoisonedADT -> Maybe NoPoisonADT
 rp_adt (Type.ADT id name type_vars variants) = Type.ADT id name type_vars <$> mapM rp_variant variants
@@ -47,6 +49,10 @@ rp_adt (Type.ADT id name type_vars variants) = Type.ADT id name type_vars <$> ma
 
 rp_type_synonym :: PoisonedTypeSynonym -> Maybe NoPoisonTypeSynonym
 rp_type_synonym (Type.TypeSynonym id name expansion) = Type.TypeSynonym id name <$> expansion
+
+rp_group :: BackendIR.BindingGroup PoisonedTopologicalSortStatus -> Maybe (BackendIR.BindingGroup NoPoisonTopologicalSortStatus)
+rp_group (BackendIR.BindingGroup (Right BackendIR.TopologicallySorted) bindings) = Just (BackendIR.BindingGroup BackendIR.TopologicallySorted bindings)
+rp_group (BackendIR.BindingGroup (Left BackendIR.HasLoops) _) = Nothing
 
 rp_binding :: PoisonedBinding -> Maybe NoPoisonBinding
 rp_binding (BackendIR.Binding initializer) = BackendIR.Binding <$> rp_expr initializer
@@ -61,7 +67,7 @@ rp_expr (BackendIR.Expr'Char id ty c) = ty >>= \ ty -> pure (BackendIR.Expr'Char
 rp_expr (BackendIR.Expr'String id ty t) = ty >>= \ ty -> pure (BackendIR.Expr'String id ty t)
 rp_expr (BackendIR.Expr'Tuple id ty a b) = ty >>= \ ty -> pure (BackendIR.Expr'Tuple id ty a b)
 
-rp_expr (BackendIR.Expr'Lambda id ty a c g r) = ty >>= \ ty -> pure (BackendIR.Expr'Lambda id ty a c g r)
+rp_expr (BackendIR.Expr'Lambda id ty a c g r) = ty >>= \ ty -> rp_group g >>= \ g -> pure (BackendIR.Expr'Lambda id ty a c g r)
 rp_expr (BackendIR.Expr'Param id ty p) = ty >>= \ ty -> pure (BackendIR.Expr'Param id ty p)
 
 rp_expr (BackendIR.Expr'Call id ty c a) = ty >>= \ ty -> pure (BackendIR.Expr'Call id ty c a)
@@ -75,7 +81,7 @@ rp_expr (BackendIR.Expr'Match id ty t) = ty >>= \ ty -> rp_tree t >>= \ t -> pur
                         (,)
                             <$> mapM rp_clause clauses
                             <*> case result of
-                                    Right e -> Just $ Right e
+                                    Right (group, e) -> rp_group group >>= \ group -> Just (Right (group, e))
                                     Left subtree -> Left <$> rp_tree subtree
                     )
                     arms
@@ -93,7 +99,7 @@ rp_expr (BackendIR.Expr'TupleDestructure2 id ty t) = ty >>= \ ty -> pure (Backen
 rp_expr (BackendIR.Expr'ADTDestructure id ty b (Right field)) = ty >>= \ ty -> pure (BackendIR.Expr'ADTDestructure id ty b (Right field))
 rp_expr (BackendIR.Expr'ADTDestructure _ _ _ (Left ())) = Nothing
 
-rp_expr (BackendIR.Expr'Forall id ty vars group e) = ty >>= \ ty -> pure (BackendIR.Expr'Forall id ty vars group e)
+rp_expr (BackendIR.Expr'Forall id ty vars group e) = ty >>= \ ty -> rp_group group >>= \ group -> pure (BackendIR.Expr'Forall id ty vars group e)
 rp_expr (BackendIR.Expr'TypeApply id ty e arg) = ty >>= \ ty -> arg >>= \ arg -> pure (BackendIR.Expr'TypeApply id ty e arg)
 
 rp_expr (BackendIR.Expr'MakeADT id ty variant tyargs args) = ty >>= \ ty -> sequence tyargs >>= \ tyargs -> pure (BackendIR.Expr'MakeADT id ty variant tyargs args)

--- a/src/UHF/Parts/ToANFIR.hs
+++ b/src/UHF/Parts/ToANFIR.hs
@@ -18,9 +18,11 @@ import qualified UHF.Data.RIR as RIR
 import qualified UHF.Util.Arena as Arena
 import qualified UHF.Util.IDGen as IDGen
 
+-- TODO: remove these type synonyms
 type RIRExpr = RIR.Expr
 type RIRBinding = RIR.Binding
 
+-- TODO: remove these type synonyms
 type ANFIR = ANFIR.ANFIR
 type ANFIRExpr = ANFIR.Expr
 type ANFIRParam = ANFIR.Param
@@ -32,61 +34,29 @@ type VariableArena = Arena.Arena RIR.Variable RIR.VariableKey
 type BindingArena b = Arena.Arena b ANFIR.BindingKey
 type ANFIRParamArena = Arena.Arena ANFIRParam ANFIR.ParamKey
 
+-- TODO: turn this into a monad transformer like ReaderT?
 type NeedsVarMap e = VariableMap -> e
-type NeedsTopoSort result = Reader (BindingArena AlmostExpr) result
 
 type VariableMap = Map.Map RIR.VariableKey ANFIR.BindingKey
 
 type MakeGraphState binding = WriterT VariableMap (StateT (BindingArena binding, ANFIRParamArena) (IDGen.IDGenT ID.ExprID (Reader VariableArena)))
 
--- the same thing as ANFIR.Expr except lambdas dont have captures and all the binding groups are actually just [BindingKey]
-data AlmostExpr
-    = AlmostExpr'Refer ANFIR.ID (Maybe Type.Type) ANFIR.BindingKey
-    | AlmostExpr'Intrinsic ANFIR.ID (Maybe Type.Type) Intrinsics.IntrinsicBoundValue
-
-    | AlmostExpr'Int ANFIR.ID (Maybe Type.Type) Integer
-    | AlmostExpr'Float ANFIR.ID (Maybe Type.Type) Rational
-    | AlmostExpr'Bool ANFIR.ID (Maybe Type.Type) Bool
-    | AlmostExpr'Char ANFIR.ID (Maybe Type.Type) Char
-    | AlmostExpr'String ANFIR.ID (Maybe Type.Type) Text
-    | AlmostExpr'Tuple ANFIR.ID (Maybe Type.Type) ANFIR.BindingKey ANFIR.BindingKey
-    | AlmostExpr'MakeADT ANFIR.ID (Maybe Type.Type) Type.ADT.VariantIndex [Maybe Type.Type] [ANFIR.BindingKey]
-
-    | AlmostExpr'Lambda ANFIR.ID (Maybe Type.Type) ANFIR.ParamKey [ANFIR.BindingKey] ANFIR.BindingKey
-    | AlmostExpr'Param ANFIR.ID (Maybe Type.Type) ANFIR.ParamKey
-
-    | AlmostExpr'Call ANFIR.ID (Maybe Type.Type) ANFIR.BindingKey ANFIR.BindingKey
-
-    | AlmostExpr'Match ANFIR.ID (Maybe Type.Type) AlmostMatchTree
-
-    | AlmostExpr'TupleDestructure1 ANFIR.ID (Maybe Type.Type) ANFIR.BindingKey
-    | AlmostExpr'TupleDestructure2 ANFIR.ID (Maybe Type.Type) ANFIR.BindingKey
-    | AlmostExpr'ADTDestructure ANFIR.ID (Maybe Type.Type) ANFIR.BindingKey (Maybe Type.ADT.FieldIndex)
-
-    | AlmostExpr'Forall ANFIR.ID (Maybe Type.Type) Type.QuantVarKey [ANFIR.BindingKey] ANFIR.BindingKey
-    | AlmostExpr'TypeApply ANFIR.ID (Maybe Type.Type) ANFIR.BindingKey (Maybe Type.Type)
-
-    | AlmostExpr'Poison ANFIR.ID (Maybe Type.Type)
-
-data AlmostMatchTree
-    = AlmostMatchTree [([ANFIR.MatchClause], Either AlmostMatchTree ([ANFIR.BindingKey], ANFIR.BindingKey))]
+newtype AccumBindingGroup = AccumBindingGroup { un_accum_bg :: ANFIR.BindingGroup }
+instance Semigroup AccumBindingGroup where
+    AccumBindingGroup (ANFIR.BindingGroup ANFIR.TopologicallySorted bindings1) <> AccumBindingGroup (ANFIR.BindingGroup ANFIR.TopologicallySorted bindings2) = AccumBindingGroup (ANFIR.BindingGroup ANFIR.TopologicallySorted (bindings1 <> bindings2))
+    AccumBindingGroup (ANFIR.BindingGroup _ bindings1) <> AccumBindingGroup (ANFIR.BindingGroup _ bindings2) = AccumBindingGroup (ANFIR.BindingGroup ANFIR.HasLoops (bindings1 <> bindings2))
+instance Monoid AccumBindingGroup where
+    mempty = AccumBindingGroup $ ANFIR.BindingGroup ANFIR.TopologicallySorted []
 
 convert :: RIR.RIR -> ANFIR
-convert (RIR.RIR modules adts type_synonyms type_vars variables (RIR.CU root_module main_function)) =
-    let (bindings_step_1, params, cu_step_1) = convert_step_1 variables (Arena.get modules root_module) main_function
-        (bindings_step_2, cu_step_2) = convert_step_2 bindings_step_1 cu_step_1
-    in ANFIR.ANFIR adts type_synonyms type_vars bindings_step_2 params cu_step_2
+convert (RIR.RIR adts type_synonyms type_vars variables cu) =
+    let ((cu', var_map), (bindings_needs_var_map, params)) = runReader (IDGen.run_id_gen_t ID.ExprID'ANFIRGen (runStateT (runWriterT (make_cu cu)) (Arena.new, Arena.new))) variables
+        cu'' = cu' var_map
+        bindings = Arena.transform (ANFIR.Binding . ($ var_map)) bindings_needs_var_map
+    in ANFIR.ANFIR adts type_synonyms type_vars bindings params cu''
 
--- step 1: converting from rir to almost anfir {{{1
-convert_step_1 :: VariableArena -> RIR.Module -> Maybe RIR.VariableKey -> (BindingArena AlmostExpr, ANFIRParamArena, NeedsTopoSort ANFIR.CU)
-convert_step_1 variables mod main_function =
-    let ((cu_needs_deps_and_var_map, var_map), (bindings_needs_var_map, params)) = runReader (IDGen.run_id_gen_t ID.ExprID'ANFIRGen (runStateT (runWriterT (make_cu main_function mod)) (Arena.new, Arena.new))) variables
-        bindings_needs_deps = Arena.transform ($ var_map) bindings_needs_var_map
-        cu_needs_deps = cu_needs_deps_and_var_map var_map
-    in (bindings_needs_deps, params, cu_needs_deps)
-
-make_cu :: Maybe RIR.VariableKey -> RIR.Module -> MakeGraphState (NeedsVarMap AlmostExpr) (NeedsVarMap (NeedsTopoSort ANFIR.CU))
-make_cu main_function (RIR.Module _ bindings adts type_synonyms) = concat <$> mapM convert_binding bindings >>= \ bindings -> pure (\ var_map -> make_binding_group bindings >>= \ group -> pure (ANFIR.CU ((var_map Map.!) <$> main_function) group adts type_synonyms))
+make_cu :: RIR.CU -> MakeGraphState (NeedsVarMap ANFIR.Expr) (NeedsVarMap ANFIR.CU)
+make_cu (RIR.CU bindings adts type_synonyms main_function) = convert_bindings bindings >>= \ group -> pure (\ var_map -> ANFIR.CU ((var_map Map.!) <$> main_function) group adts type_synonyms)
 
 map_variable :: RIR.VariableKey -> ANFIR.BindingKey -> MakeGraphState binding ()
 map_variable k binding = tell $ Map.singleton k binding
@@ -94,16 +64,26 @@ map_variable k binding = tell $ Map.singleton k binding
 get_var :: RIR.VariableKey -> MakeGraphState binding RIR.Variable
 get_var k = lift $ lift $ lift $ reader (\ a -> Arena.get a k)
 
-convert_binding :: RIRBinding -> MakeGraphState (NeedsVarMap AlmostExpr) [ANFIR.BindingKey]
-convert_binding (RIR.Binding target expr) =
-    get_var target >>= \ (RIR.Variable varid _ _) ->
-    runWriterT (convert_expr (Just varid) expr) >>= \ (expr_result_binding, expr_involved_bindings) ->
-    map_variable target expr_result_binding >>
-    pure expr_involved_bindings
+convert_bindings :: RIR.Bindings -> MakeGraphState (NeedsVarMap ANFIR.Expr) ANFIR.BindingGroup
+convert_bindings (RIR.Bindings topological_sort_status bindings) = do
+    -- the resulting accum_status is based on whether or not the binding groups within bindings have unsorted binding groups
+    -- but if the source rir binding group was not topologically sorted then it doesnt matter whether or not the binding groups within it were and this resulting binding group should not be marked as sorted anwyays
+    (AccumBindingGroup (ANFIR.BindingGroup accum_status accum_bindings)) <- execWriterT $ mapM convert_binding bindings
+    pure (ANFIR.BindingGroup (convert_topological_sort_status accum_status topological_sort_status) accum_bindings)
+    where
+        convert_topological_sort_status ANFIR.TopologicallySorted RIR.TopologicallySorted = ANFIR.TopologicallySorted
+        convert_topological_sort_status _ _ = ANFIR.HasLoops
 
-new_binding :: binding -> WriterT [ANFIR.BindingKey] (MakeGraphState binding) ANFIR.BindingKey
-new_binding binding = lift (lift $ state $ \ (bindings, params) -> let (i, bindings') = Arena.put binding bindings in (i, (bindings', params))) >>= \ binding_key -> tell [binding_key] >> pure binding_key
-new_param :: ANFIRParam -> WriterT [ANFIR.BindingKey] (MakeGraphState binding) ANFIR.ParamKey
+convert_binding :: RIRBinding -> WriterT AccumBindingGroup (MakeGraphState (NeedsVarMap ANFIR.Expr)) ANFIR.BindingKey
+convert_binding (RIR.Binding target expr) =
+    lift (get_var target) >>= \ (RIR.Variable varid _ _) ->
+    convert_expr (Just varid) expr >>= \ expr_result_binding ->
+    lift (map_variable target expr_result_binding) >>
+    pure expr_result_binding
+
+new_binding :: binding -> WriterT AccumBindingGroup (MakeGraphState binding) ANFIR.BindingKey
+new_binding binding = lift (lift $ state $ \ (bindings, params) -> let (i, bindings') = Arena.put binding bindings in (i, (bindings', params))) >>= \ binding_key -> tell (AccumBindingGroup $ ANFIR.BindingGroup ANFIR.TopologicallySorted [binding_key]) >> pure binding_key
+new_param :: ANFIRParam -> WriterT AccumBindingGroup (MakeGraphState binding) ANFIR.ParamKey
 new_param param = lift (lift $ state $ \ (bindings, params) -> let (i, params') = Arena.put param params in (i, (bindings, params')))
 
 new_expr_id :: MakeGraphState binding ID.ExprID
@@ -113,51 +93,51 @@ choose_id :: Maybe ID.VariableID -> ID.ExprID -> ANFIR.ID
 choose_id (Just varid) _ = ANFIR.VarID varid
 choose_id Nothing eid = ANFIR.ExprID eid
 
-convert_expr :: Maybe ID.VariableID -> RIR.Expr -> WriterT [ANFIR.BindingKey] (MakeGraphState (NeedsVarMap AlmostExpr)) ANFIR.BindingKey
+convert_expr :: Maybe ID.VariableID -> RIR.Expr -> WriterT AccumBindingGroup (MakeGraphState (NeedsVarMap ANFIR.Expr)) ANFIR.BindingKey
 convert_expr m_varid expr@(RIR.Expr'Identifier id _ _ varkey) =
     lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in
     case varkey of
-        Just varkey -> new_binding $ \ var_map -> AlmostExpr'Refer (choose_id m_varid id) ty (var_map Map.! varkey)
-        Nothing -> new_binding $ \ _ -> AlmostExpr'Poison (choose_id m_varid id) ty
+        Just varkey -> new_binding $ \ var_map -> ANFIR.Expr'Refer (choose_id m_varid id) ty (var_map Map.! varkey)
+        Nothing -> new_binding $ \ _ -> ANFIR.Expr'Poison (choose_id m_varid id) ty
 convert_expr m_varid expr@(RIR.Expr'Intrinsic id _ _ i) =
     lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in
-    new_binding $ \ var_map -> AlmostExpr'Intrinsic (choose_id m_varid id) ty i
-convert_expr m_varid expr@(RIR.Expr'Char id _ c) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> AlmostExpr'Char (choose_id m_varid id) ty c)
+    new_binding $ \ var_map -> ANFIR.Expr'Intrinsic (choose_id m_varid id) ty i
+convert_expr m_varid expr@(RIR.Expr'Char id _ c) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> ANFIR.Expr'Char (choose_id m_varid id) ty c)
 
-convert_expr m_varid expr@(RIR.Expr'String id _ s) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> AlmostExpr'String (choose_id m_varid id) ty s)
-convert_expr m_varid expr@(RIR.Expr'Int id _ i) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> AlmostExpr'Int (choose_id m_varid id) ty i)
-convert_expr m_varid expr@(RIR.Expr'Float id _ f) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> AlmostExpr'Float (choose_id m_varid id) ty f)
-convert_expr m_varid expr@(RIR.Expr'Bool id _ b) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> AlmostExpr'Bool (choose_id m_varid id) ty b)
+convert_expr m_varid expr@(RIR.Expr'String id _ s) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> ANFIR.Expr'String (choose_id m_varid id) ty s)
+convert_expr m_varid expr@(RIR.Expr'Int id _ i) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> ANFIR.Expr'Int (choose_id m_varid id) ty i)
+convert_expr m_varid expr@(RIR.Expr'Float id _ f) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> ANFIR.Expr'Float (choose_id m_varid id) ty f)
+convert_expr m_varid expr@(RIR.Expr'Bool id _ b) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in new_binding (\ _ -> ANFIR.Expr'Bool (choose_id m_varid id) ty b)
 
-convert_expr m_varid expr@(RIR.Expr'Tuple id _ a b) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in convert_expr Nothing a >>= \ a -> convert_expr Nothing b >>= \ b -> new_binding (\ _ -> AlmostExpr'Tuple (choose_id m_varid id) ty a b)
+convert_expr m_varid expr@(RIR.Expr'Tuple id _ a b) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in convert_expr Nothing a >>= \ a -> convert_expr Nothing b >>= \ b -> new_binding (\ _ -> ANFIR.Expr'Tuple (choose_id m_varid id) ty a b)
 
-convert_expr m_varid expr@(RIR.Expr'Lambda id _ param_var body) =
+convert_expr m_varid expr@(RIR.Expr'Lambda id _ param_var captures body) = -- TODO: use captures
     lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in
     lift (get_var param_var) >>= \ (RIR.Variable param_id param_ty _) ->
     new_param (ANFIR.Param param_id param_ty) >>= \ anfir_param ->
     lift (runWriterT $ -- lambda bodies should not be included in the parent included bindings because they do not need to be evaluated to create the lambda object
         lift new_expr_id >>= \ param_binding_id ->
-        new_binding (\ _ -> AlmostExpr'Param (ANFIR.ExprID param_binding_id) param_ty anfir_param) >>= \ param_binding ->
+        new_binding (\ _ -> ANFIR.Expr'Param (ANFIR.ExprID param_binding_id) param_ty anfir_param) >>= \ param_binding ->
         lift (map_variable param_var param_binding) >>
         convert_expr Nothing body
     ) >>= \ (body, body_included_bindings) ->
 
-    new_binding (\ _ -> AlmostExpr'Lambda (choose_id m_varid id) ty anfir_param body_included_bindings body)
+    new_binding (\ var_map -> ANFIR.Expr'Lambda (choose_id m_varid id) ty anfir_param (Set.map (var_map Map.!) captures) (un_accum_bg body_included_bindings) body)
 
 convert_expr m_varid (RIR.Expr'Let id _ bindings adts type_synonyms result) = do
     var_arena <- lift $ lift $ lift $ lift ask
     let result_ty = RIR.expr_type var_arena result
-    bindings <- mapM (lift . convert_binding) bindings
-    tell (concat bindings)
+    bindings <- lift $ convert_bindings bindings
+    tell (AccumBindingGroup bindings)
     -- TODO: deal with adts and type synonyms properly
     convert_expr Nothing result
 
-convert_expr m_varid expr@(RIR.Expr'Call id _ callee arg) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in convert_expr Nothing callee >>= \ callee -> convert_expr Nothing arg >>= \ arg -> new_binding (\ _ -> AlmostExpr'Call (choose_id m_varid id) ty callee arg)
+convert_expr m_varid expr@(RIR.Expr'Call id _ callee arg) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in convert_expr Nothing callee >>= \ callee -> convert_expr Nothing arg >>= \ arg -> new_binding (\ _ -> ANFIR.Expr'Call (choose_id m_varid id) ty callee arg)
 
 convert_expr m_varid (RIR.Expr'Match id ty _ tree) =
     lift (convert_tree tree) >>= \ tree ->
 
-    new_binding (\ var_map -> AlmostExpr'Match (choose_id m_varid id) ty (tree var_map))
+    new_binding (\ var_map -> ANFIR.Expr'Match (choose_id m_varid id) ty (tree var_map))
     where
         convert_tree (RIR.MatchTree arms) =
             mapM
@@ -166,13 +146,13 @@ convert_expr m_varid (RIR.Expr'Match id ty _ tree) =
                     (case result of
                         Right e ->
                             runWriterT (convert_expr Nothing e) >>= \ (result, result_involved_bindings) ->
-                            pure (\ _ -> Right (result_involved_bindings, result))
+                            pure (\ _ -> Right (un_accum_bg result_involved_bindings, result))
                         Left subtree ->
                             convert_tree subtree >>= \ subtree ->
                             pure (\ var_map -> Left (subtree var_map))) >>= \ result ->
                     pure (\ var_map -> (concatMap ($ var_map) clauses, result var_map)))
                 arms >>= \ arms ->
-            pure (\ var_map -> AlmostMatchTree (map ($ var_map) arms))
+            pure (\ var_map -> ANFIR.MatchTree (map ($ var_map) arms))
 
         convert_clause (RIR.MatchClause'Match binding (RIR.Match'BoolLiteral bool)) = pure (\ var_map -> [ANFIR.MatchClause'Match (var_map Map.! binding) (ANFIR.Match'BoolLiteral bool)])
         convert_clause (RIR.MatchClause'Match c RIR.Match'Tuple) = pure (\ var_map -> [ANFIR.MatchClause'Match (var_map Map.! c) ANFIR.Match'Tuple])
@@ -187,161 +167,32 @@ convert_expr m_varid (RIR.Expr'Match id ty _ tree) =
             get_var other >>= \ (RIR.Variable _ other_ty _) ->
             new_expr_id >>= \ id ->
             -- second element is all the bindings made, but because there is only one call to new_binding in this WriterT, the only binding ever made is this one, so we do not need to keep track of the second variable
-            runWriterT (new_binding (\ var_map -> AlmostExpr'Refer (ANFIR.ExprID id) other_ty (var_map Map.! other))) >>= \ (binding, _) ->
+            runWriterT (new_binding (\ var_map -> ANFIR.Expr'Refer (ANFIR.ExprID id) other_ty (var_map Map.! other))) >>= \ (binding, _) ->
             pure binding
         convert_assign_rhs (RIR.MatchAssignRHS'TupleDestructure1 ty tup) =
             new_expr_id >>= \ id ->
-            runWriterT (new_binding (\ var_map -> AlmostExpr'TupleDestructure1 (ANFIR.ExprID id) ty (var_map Map.! tup))) >>= \ (binding, _) -> -- same note about all the bindings made as above
+            runWriterT (new_binding (\ var_map -> ANFIR.Expr'TupleDestructure1 (ANFIR.ExprID id) ty (var_map Map.! tup))) >>= \ (binding, _) -> -- same note about all the bindings made as above
             pure binding
         convert_assign_rhs (RIR.MatchAssignRHS'TupleDestructure2 ty tup) =
             new_expr_id >>= \ id ->
-            runWriterT (new_binding (\ var_map -> AlmostExpr'TupleDestructure2 (ANFIR.ExprID id) ty (var_map Map.! tup))) >>= \ (binding, _) -> -- same note as above
+            runWriterT (new_binding (\ var_map -> ANFIR.Expr'TupleDestructure2 (ANFIR.ExprID id) ty (var_map Map.! tup))) >>= \ (binding, _) -> -- same note as above
             pure binding
         convert_assign_rhs (RIR.MatchAssignRHS'AnonADTVariantField ty base field_idx) =
             new_expr_id >>= \ id ->
-            runWriterT (new_binding (\ var_map -> AlmostExpr'ADTDestructure (ANFIR.ExprID id) ty (var_map Map.! base) field_idx)) >>= \ (binding, _) -> -- same note as above
+            runWriterT (new_binding (\ var_map -> ANFIR.Expr'ADTDestructure (ANFIR.ExprID id) ty (var_map Map.! base) field_idx)) >>= \ (binding, _) -> -- same note as above
             pure binding
 
 convert_expr m_varid expr@(RIR.Expr'Forall id _ vars e) = go (toList vars) e
     where
-        go [] result = convert_expr Nothing e
+        go [] result = convert_expr Nothing result
         go (var:vars) result =
             lift (lift $ lift $ lift ask) >>= \ var_arena ->
             let result_ty = RIR.expr_type var_arena result
             in lift (runWriterT (go vars result)) >>= \ (result, result_bindings) ->
             lift new_expr_id >>= \ eid ->
-            new_binding (\ _ -> AlmostExpr'Forall (ANFIR.ExprID eid) (Type.Type'Forall (var:|[]) <$> result_ty) var result_bindings result)
-convert_expr m_varid (RIR.Expr'TypeApply id ty _ e arg) = convert_expr Nothing e >>= \ e -> new_binding (\ _ -> AlmostExpr'TypeApply (choose_id m_varid id) ty e arg)
+            new_binding (\ _ -> ANFIR.Expr'Forall (ANFIR.ExprID eid) (Type.Type'Forall (var:|[]) <$> result_ty) var (un_accum_bg result_bindings) result)
+convert_expr m_varid (RIR.Expr'TypeApply id ty _ e arg) = convert_expr Nothing e >>= \ e -> new_binding (\ _ -> ANFIR.Expr'TypeApply (choose_id m_varid id) ty e arg)
 
-convert_expr m_varid expr@(RIR.Expr'MakeADT id _ variant tyargs args) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in mapM (convert_expr Nothing) args >>= \ args -> new_binding (\ _ -> AlmostExpr'MakeADT (choose_id m_varid id) ty variant tyargs args)
+convert_expr m_varid expr@(RIR.Expr'MakeADT id _ variant tyargs args) = lift (lift $ lift $ lift ask) >>= \ var_arena -> let ty = RIR.expr_type var_arena expr in mapM (convert_expr Nothing) args >>= \ args -> new_binding (\ _ -> ANFIR.Expr'MakeADT (choose_id m_varid id) ty variant tyargs args)
 
-convert_expr m_varid (RIR.Expr'Poison id ty _) = new_binding (\ _ -> AlmostExpr'Poison (choose_id m_varid id) ty)
--- second step: converting from almost anfir to actual anfir {{{1
-convert_step_2 :: BindingArena AlmostExpr -> Reader (BindingArena AlmostExpr) ANFIR.CU -> (BindingArena ANFIR.Binding, ANFIR.CU)
-convert_step_2 bindings cu =
-    let bindings' = runReader (Arena.transformM (\ x -> ANFIR.Binding <$> convert_almost_expr x) bindings) bindings
-        cu' = runReader cu bindings
-    in (bindings', cu')
-convert_almost_expr :: AlmostExpr -> Reader (BindingArena AlmostExpr) ANFIR.Expr
-convert_almost_expr (AlmostExpr'Refer id ty bk) = pure $ ANFIR.Expr'Refer id ty bk
-convert_almost_expr (AlmostExpr'Intrinsic id ty i) = pure $ ANFIR.Expr'Intrinsic id ty i
-convert_almost_expr (AlmostExpr'Int id ty i) = pure $ ANFIR.Expr'Int id ty i
-convert_almost_expr (AlmostExpr'Float id ty f) = pure $ ANFIR.Expr'Float id ty f
-convert_almost_expr (AlmostExpr'Bool id ty b) = pure $ ANFIR.Expr'Bool id ty b
-convert_almost_expr (AlmostExpr'Char id ty c) = pure $ ANFIR.Expr'Char id ty c
-convert_almost_expr (AlmostExpr'String id ty s) = pure $ ANFIR.Expr'String id ty s
-convert_almost_expr (AlmostExpr'Tuple id ty a b) = pure $ ANFIR.Expr'Tuple id ty a b
-convert_almost_expr (AlmostExpr'MakeADT id ty var_idx tyargs args) = pure $ ANFIR.Expr'MakeADT id ty var_idx tyargs args
-convert_almost_expr (AlmostExpr'Lambda id ty param bindings result) = ANFIR.Expr'Lambda id ty param <$> get_dependencies_of_binding_list_and_expr bindings result <*> make_binding_group bindings <*> pure result
-convert_almost_expr (AlmostExpr'Param id ty param) = pure $ ANFIR.Expr'Param id ty param
-convert_almost_expr (AlmostExpr'Call id ty callee arg) = pure $ ANFIR.Expr'Call id ty callee arg
-convert_almost_expr (AlmostExpr'Match id ty tree) = ANFIR.Expr'Match id ty <$> convert_tree tree
-    where
-        convert_tree (AlmostMatchTree arms) =
-            ANFIR.MatchTree
-                <$> mapM
-                    (\ (clauses, result) ->
-                        (case result of
-                            Left subtree -> Left <$> convert_tree subtree
-                            Right (bindings, res) -> Right <$> ((, res) <$> make_binding_group bindings)) >>= \ result ->
-                        pure (clauses, result)
-                    )
-                    arms
-convert_almost_expr (AlmostExpr'TupleDestructure1 id ty tup) = pure $ ANFIR.Expr'TupleDestructure1 id ty tup
-convert_almost_expr (AlmostExpr'TupleDestructure2 id ty tup) = pure $ ANFIR.Expr'TupleDestructure2 id ty tup
-convert_almost_expr (AlmostExpr'ADTDestructure id ty base field_idx) = pure $ ANFIR.Expr'ADTDestructure id ty base field_idx
-convert_almost_expr (AlmostExpr'Forall id ty qvar bindings result) = ANFIR.Expr'Forall id ty qvar <$> make_binding_group bindings <*> pure result
-convert_almost_expr (AlmostExpr'TypeApply id ty e tyarg) = pure $ ANFIR.Expr'TypeApply id ty e tyarg
-convert_almost_expr (AlmostExpr'Poison id ty) = pure $ ANFIR.Expr'Poison id ty
-get_dependencies_of_binding_list_and_expr :: [ANFIR.BindingKey] -> ANFIR.BindingKey -> Reader (BindingArena AlmostExpr) (Set ANFIR.BindingKey)
-get_dependencies_of_binding_list_and_expr bindings e =
-    Set.unions <$> mapM get_dependencies_of_almost_expr bindings >>= \ bindings_dependencies ->
-    pure ((bindings_dependencies <> [e]) `Set.difference` Set.fromList bindings)
-get_dependencies_of_almost_expr :: ANFIR.BindingKey -> Reader (BindingArena AlmostExpr) (Set.Set ANFIR.BindingKey)
-get_dependencies_of_almost_expr bk =
-    ask >>= \ binding_arena ->
-    case Arena.get binding_arena bk of
-        AlmostExpr'Refer _ _ i -> pure [i]
-        AlmostExpr'Intrinsic _ _ _ -> pure []
-        AlmostExpr'Char _ _ _ -> pure []
-        AlmostExpr'String _ _ _ -> pure []
-        AlmostExpr'Int _ _ _ -> pure []
-        AlmostExpr'Float _ _ _ -> pure []
-        AlmostExpr'Bool _ _ _ -> pure []
-        AlmostExpr'Tuple _ _ a b -> pure [a, b]
-        AlmostExpr'Lambda _ _ _ bindings result -> get_dependencies_of_binding_list_and_expr bindings result
-        AlmostExpr'Param _ _ _ -> pure []
-        AlmostExpr'Call _ _ callee arg -> pure [callee, arg]
-        AlmostExpr'Match _ _ tree -> go_through_tree tree
-            where
-                go_through_tree (AlmostMatchTree arms) =
-                    arms
-                        & mapM
-                            (\ (clauses, result) ->
-                                let (referenced_in_clauses, bindings_defined_in_clauses) = clauses
-                                        & map go_through_clause
-                                        & unzip
-                                in
-                                (case result of
-                                    Left subtree -> go_through_tree subtree
-                                    Right (bindings, e) -> get_dependencies_of_binding_list_and_expr bindings e) >>= \ result_dependencies ->
-                                pure ((Set.unions referenced_in_clauses <> result_dependencies) `Set.difference` Set.unions bindings_defined_in_clauses)
-                            )
-                        <&> Set.unions
-                -- first element is bindings referenced, second element is bindings defined
-                go_through_clause (ANFIR.MatchClause'Match binding _) = ([binding], [])
-                go_through_clause (ANFIR.MatchClause'Binding b) = ([], [b])
-        AlmostExpr'TupleDestructure1 _ _ tup -> pure [tup]
-        AlmostExpr'TupleDestructure2 _ _ tup -> pure [tup]
-        AlmostExpr'ADTDestructure _ _ base _ -> pure [base]
-        AlmostExpr'Forall _ _ _ bindings e -> get_dependencies_of_binding_list_and_expr bindings e
-        AlmostExpr'TypeApply _ _ e _ -> pure [e]
-        AlmostExpr'MakeADT _ _ _ _ args -> pure $ Set.fromList args
-        AlmostExpr'Poison _ _ -> pure []
-make_binding_group :: [ANFIR.BindingKey] -> Reader (BindingArena AlmostExpr) ANFIRBindingGroup
-make_binding_group bindings =
-    Map.fromList <$> mapM (\ b -> (b,) <$> get_dependencies_of_almost_expr b) bindings >>= \ binding_dependencies ->
-    let binding_dependencies_only_here = Map.map (Set.filter (`elem` bindings)) binding_dependencies
-    in topological_sort binding_dependencies_only_here [] bindings >>= \ bindings_sorted ->
-    pure (ANFIR.BindingGroup bindings_sorted)
-    where
-        topological_sort _ done [] = pure done
-        topological_sort binding_dependencies done left =
-            case List.partition dependencies_satisfied left of
-                ([], waiting) ->
-                    let (loops, not_loop) = find_loops waiting
-                    in mapM deal_with_loop loops >>= \ loops ->
-                    topological_sort binding_dependencies (done ++ loops) not_loop
-                (ready, waiting) -> topological_sort binding_dependencies (done ++ map ANFIR.SingleBinding ready) waiting
-            where
-                dependencies_satisfied bk = and $ Set.map (`List.elem` concatMap ANFIR.chunk_bindings done) (binding_dependencies Map.! bk)
-                find_loops = find [] []
-                    where
-                        find loops not_in_loop [] = (loops, not_in_loop)
-                        find loops not_in_loop searching_for_loops_in@(first:more) =
-                            case trace_single_loop [] first more of
-                                Just (loop, bks_not_in_loop, remaining') -> find (loop:loops) (not_in_loop ++ bks_not_in_loop) remaining'
-                                Nothing -> find loops (first:not_in_loop) more
-                            where
-                                trace_single_loop visited_stack current unvisited =
-                                    case List.elemIndex current visited_stack of
-                                        Just current_idx ->
-                                            let (loop, not_in_loop) = splitAt (current_idx + 1) visited_stack -- top of stack is at beginning
-                                            in Just (loop, not_in_loop, unvisited) -- all items of visited stack and current should not be in unvisited
-                                        Nothing ->
-                                            let current_dependencies = binding_dependencies Map.! current
-                                            in headMay $
-                                                mapMaybe
-                                                    (\ neighbor -> trace_single_loop (current:visited_stack) neighbor (filter (/=neighbor) unvisited))
-                                                    (toList $ Set.filter (`elem` searching_for_loops_in) current_dependencies)
-                deal_with_loop loop =
-                    ask >>= \ binding_arena ->
-                    if all (allowed_in_loop . Arena.get binding_arena) loop
-                        then pure $ ANFIR.MutuallyRecursiveBindings loop
-                        else error "illegal loop" -- TODO: proper error message for this
-                    where
-                        -- TODO: fix this because this allows loops where with only foralls
-                        -- eg x = #(A) x#(A) is allowed
-                        allowed_in_loop (AlmostExpr'Lambda _ _ _ _ _) = True
-                        allowed_in_loop (AlmostExpr'Forall _ _ _ _ _) = True
-                        allowed_in_loop _ = False
+convert_expr m_varid (RIR.Expr'Poison id ty _) = new_binding (\ _ -> ANFIR.Expr'Poison (choose_id m_varid id) ty)

--- a/src/UHF/Parts/ToRIR/TopologicalSort.hs
+++ b/src/UHF/Parts/ToRIR/TopologicalSort.hs
@@ -1,0 +1,359 @@
+{-# LANGUAGE OverloadedLists #-}
+
+module UHF.Parts.ToRIR.TopologicalSort (BindingsHaveLoopError, sort_bindings, get_captures) where
+
+import UHF.Prelude
+
+import qualified Data.List as List
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+import UHF.Source.Span (Span)
+import qualified UHF.Data.RIR as RIR
+import qualified UHF.Diagnostic as Diagnostic
+import qualified UHF.Util.Arena as Arena
+
+data Dependency = NeedsInitialized RIR.VariableKey | NeedsCallable RIR.VariableKey deriving (Eq, Ord, Show)
+
+data BindingsHaveLoopError
+    = BindingsHaveLoop (Map RIR.VariableKey Span) [Dependency]
+
+instance Diagnostic.ToError BindingsHaveLoopError where
+    -- TODO: improve this error message
+    to_error (BindingsHaveLoop spans deps@(loop_start:more)) =
+        let middle_deps = init more
+            last_dep = last more
+        in Diagnostic.Error (Just $ dep_span loop_start) "illegal loop in bindings"
+            ( loop_start_message
+                : (middle_deps & zip [2..] & map (uncurry more_dep_message))
+                ++ [last_dep_message last_dep])
+            []
+        where
+            make_counter i = "(" <> show i <> "/" <> show (length deps) <> ")"
+
+            dep_span dep = spans Map.! get_dependency_vk dep
+
+            loop_start_message = (Just (dep_span loop_start), Diagnostic.MsgError, Just $ make_counter 1 <> " the " <> dep_word_first loop_start <> " of this variable requires that...")
+            more_dep_message i dep = (Just (dep_span dep), Diagnostic.MsgNote, Just $ make_counter i <> " this variable is " <> dep_word dep <> ", which further requires that...")
+            last_dep_message dep = (Just (dep_span dep), Diagnostic.MsgNote, Just $ make_counter (length deps) <> " this variable is " <> dep_word dep <> ", completing the cycle")
+            -- the last one completes the cycle because the same dependency is at the beginning and at the end
+
+            -- TODO: especially these words
+            dep_word (NeedsInitialized _) = "already initialzied"
+            dep_word (NeedsCallable _) = "ready to be called"
+
+            dep_word_first (NeedsInitialized _) = "initialization"
+            dep_word_first (NeedsCallable _) = "callability"
+
+    to_error (BindingsHaveLoop _ []) = error "empty loop in BindingsHaveLoop error"
+
+-- TODO: remove?
+get_dependency_vk :: Dependency -> RIR.VariableKey
+get_dependency_vk (NeedsInitialized vk) = vk
+get_dependency_vk (NeedsCallable vk) = vk
+
+get_captures :: RIR.Expr -> Set RIR.VariableKey
+get_captures = get_outside_references -- the captures of a lambda are just any variables that it references that it does not define
+
+-- get all variables that are not defined within this expression and that are referred to by identifier expressions
+-- "an outside reference" = a reference to some variable defined outside of this expression
+get_outside_references :: RIR.Expr -> Set RIR.VariableKey
+get_outside_references (RIR.Expr'Identifier _ _ _ (Just i)) = [i]
+get_outside_references (RIR.Expr'Identifier _ _ _ Nothing) = []
+get_outside_references (RIR.Expr'Intrinsic _ _ _ _) = []
+get_outside_references (RIR.Expr'Char _ _ _) = []
+get_outside_references (RIR.Expr'String _ _ _) = []
+get_outside_references (RIR.Expr'Int _ _ _) = []
+get_outside_references (RIR.Expr'Float _ _ _) = []
+get_outside_references (RIR.Expr'Bool _ _ _) = []
+get_outside_references (RIR.Expr'Tuple _ _ a b) = get_outside_references a <> get_outside_references b
+get_outside_references (RIR.Expr'Lambda _ _ param captures body) = (captures <> get_outside_references body) Set.\\ Set.singleton param -- TODO: using captures is redundant, so remove? also double check if it is actually redundant or if i just think that
+get_outside_references (RIR.Expr'Let _ _ (RIR.Bindings _ bindings) _ _ result) =
+    let variables_defined_in_this_let = Set.fromList $ map (\ (RIR.Binding vk _) -> vk) bindings
+
+        variable_initializer_references = Set.unions $ map (\ (RIR.Binding _ e) -> get_outside_references e) bindings
+        result_references = get_outside_references result
+
+        all_references = variable_initializer_references <> result_references
+
+    in all_references Set.\\ variables_defined_in_this_let
+get_outside_references (RIR.Expr'Call _ _ callee arg) = get_outside_references callee <> get_outside_references arg
+get_outside_references (RIR.Expr'Match _ _ _ tree) = go_through_tree tree
+    where
+        go_through_tree (RIR.MatchTree arms) =
+            arms
+                & map
+                    (\ (clauses, result) ->
+                        let (clause_refs, defined_in_clauses) = clauses & map go_through_clause & unzip
+
+                            result_refs = case result of
+                                Left subtree -> go_through_tree subtree
+                                Right e -> get_outside_references e
+
+                        in (Set.unions clause_refs <> result_refs) Set.\\ Set.unions defined_in_clauses
+                    )
+                & Set.unions
+
+        -- first element is references, second element is variables defined
+        go_through_clause (RIR.MatchClause'Match binding _) = ([binding], [])
+        go_through_clause (RIR.MatchClause'Assign vk rhs) = (go_match_assign_rhs rhs, [vk])
+
+        go_match_assign_rhs (RIR.MatchAssignRHS'OtherVar vk) = [vk]
+        go_match_assign_rhs (RIR.MatchAssignRHS'TupleDestructure1 _ vk) = [vk]
+        go_match_assign_rhs (RIR.MatchAssignRHS'TupleDestructure2 _ vk) = [vk]
+        go_match_assign_rhs (RIR.MatchAssignRHS'AnonADTVariantField _ vk _) = [vk]
+
+get_outside_references (RIR.Expr'Forall _ _ _ e) = get_outside_references e
+get_outside_references (RIR.Expr'TypeApply _ _ _ e _) = get_outside_references e
+get_outside_references (RIR.Expr'MakeADT _ _ _ _ args) = Set.unions $ map get_outside_references args
+get_outside_references (RIR.Expr'Poison _ _ _) = []
+
+-- get the dependencies needed to evaluate an expression
+get_execute_dependencies :: RIR.Expr -> Set Dependency
+get_execute_dependencies = go
+    where
+        go (RIR.Expr'Identifier _ _ _ (Just i)) = [NeedsInitialized i]
+        go (RIR.Expr'Identifier _ _ _ Nothing) = []
+        go (RIR.Expr'Intrinsic _ _ _ _) = []
+        go (RIR.Expr'Char _ _ _) = []
+        go (RIR.Expr'String _ _ _) = []
+        go (RIR.Expr'Int _ _ _) = []
+        go (RIR.Expr'Float _ _ _) = []
+        go (RIR.Expr'Bool _ _ _) = []
+        go (RIR.Expr'Tuple _ _ a b) = get_execute_dependencies a <> get_execute_dependencies b
+        go (RIR.Expr'Lambda _ _ _ _ _) =
+            -- to execute the lambda (not execute its body, just define the body), we dont have any dependencies
+            -- we dont require that the captures have been executed because that prevents recursive functions from working (because recursive functions capture themselves)
+            []
+
+        -- a let's execute dependencies is all of the execute dependencies of its result and the execute dependencies of all of the initializers of the bindings defined in the let
+        -- we also rewrite any dependnecies on variables defined in the bindings as the dependencies of those bindings themselves
+        -- for example, in the let expression
+        --      let a = b x
+        --      a(c)
+        -- instead of returning a dependency IsCallable a, we rewrite that dependency to the call dependencies of a itself, namely [IsCallable b, IsInitialized x]
+        -- this is because the topological sort handling the topmost let does not have control over the topological sorting of the bindings defined in the let, so it will not work properly
+        go (RIR.Expr'Let _ _ (RIR.Bindings _ bindings) _ _ result) =
+            let variables_defined_here = map (\ (RIR.Binding vk e) -> (vk, get_execute_dependencies e, get_call_dependencies e)) bindings
+            in (Set.unions (map (\ (RIR.Binding _ e) -> get_execute_dependencies e) bindings) <> get_execute_dependencies result)
+                & rewrite_dependencies variables_defined_here
+
+        -- because a call expression calls an arbitrary function, it can do arbitrary things with the argument, including calling it, so we conservatively require that the argument is callable
+        go (RIR.Expr'Call _ _ callee arg) = get_call_dependencies callee <> get_call_dependencies arg
+
+        -- TODO: this has the same bug as lets do above
+        --       call dependencies on variables defined in the clauses should be replaced with their call dependencies
+        go (RIR.Expr'Match _ _ _ tree) = go_through_tree tree
+            where
+                go_through_tree (RIR.MatchTree arms) =
+                    arms
+                        & map
+                            (\ (clauses, result) ->
+                                let vars_defined_in_clauses = concatMap get_vars_defined_in_clause clauses
+                                    clause_deps = map get_clause_deps clauses
+
+                                    result_dependencies = case result of
+                                        Left subtree -> go_through_tree subtree
+                                        Right e -> get_execute_dependencies e
+
+                                in (Set.unions clause_deps <> result_dependencies) & rewrite_dependencies vars_defined_in_clauses
+                            )
+                        & Set.unions
+
+                get_vars_defined_in_clause (RIR.MatchClause'Match _ _) = []
+                get_vars_defined_in_clause (RIR.MatchClause'Assign vk rhs) = [(vk, match_rhs_exec_deps rhs, match_rhs_call_deps rhs)]
+
+                get_clause_deps (RIR.MatchClause'Match binding _) = [NeedsInitialized binding]
+                get_clause_deps (RIR.MatchClause'Assign _ rhs) = match_rhs_exec_deps rhs
+
+        go (RIR.Expr'Forall _ _ _ e) = get_execute_dependencies e
+        go (RIR.Expr'TypeApply _ _ _ e _) = get_execute_dependencies e
+        go (RIR.Expr'MakeADT _ _ _ _ args) = Set.unions $ map get_execute_dependencies args
+        go (RIR.Expr'Poison _ _ _) = []
+
+get_call_dependencies :: RIR.Expr -> Set Dependency
+get_call_dependencies = go
+    where
+        -- these expressions do not store code and therefore have no call dependencies
+        go (RIR.Expr'Char _ _ _) = []
+        go (RIR.Expr'String _ _ _) = []
+        go (RIR.Expr'Int _ _ _) = []
+        go (RIR.Expr'Float _ _ _) = []
+        go (RIR.Expr'Bool _ _ _) = []
+        go (RIR.Expr'Poison _ _ _) = []
+        go (RIR.Expr'Identifier _ _ _ Nothing) = []
+        go (RIR.Expr'Intrinsic _ _ _ _) = []
+
+        -- these expressions are only callable if the expressions it refers to are also callable
+        go (RIR.Expr'Identifier _ _ _ (Just i)) = [NeedsCallable i]
+        go (RIR.Expr'Call _ _ callee arg) =
+            -- the callee has to be callable because it is being called
+            -- the argument passed has to also be callable because the function that it is passed to can do arbitrary things to it, so we conservatively enforce that it is also callable in case the function does call it
+            -- the result of the call has to be callable, but we cannot enforce that here and instead must enforce that all lambdas must return a callable expression (see below in go for lambdas)
+            get_call_dependencies callee <> get_call_dependencies arg
+        go (RIR.Expr'Tuple _ _ a b) = get_call_dependencies a <> get_call_dependencies b
+        go (RIR.Expr'TypeApply _ _ _ e _) = get_call_dependencies e
+        go (RIR.Expr'MakeADT _ _ _ _ args) = Set.unions $ map get_call_dependencies args
+        go (RIR.Expr'Forall _ _ _ e) = get_call_dependencies e
+
+        -- a let is callable if its result is callable
+        go (RIR.Expr'Let _ _ (RIR.Bindings _ bindings) _ _ result) =
+            let variables_defined_here = map (\ (RIR.Binding vk e) -> (vk, get_execute_dependencies e, get_call_dependencies e)) bindings
+            in (get_call_dependencies result <> Set.unions (map (\ (RIR.Binding _ e) -> get_call_dependencies e) bindings))
+                & rewrite_dependencies variables_defined_here
+
+        go (RIR.Expr'Match _ _ _ tree) = go_through_tree tree
+            where
+                go_through_tree (RIR.MatchTree arms) =
+                    arms
+                        & map
+                            (\ (clauses, result) ->
+                                let vars_defined_in_clauses = concatMap get_vars_defined_in_clause clauses
+                                    clause_deps = map get_clause_deps clauses
+
+                                    result_dependencies = case result of
+                                        Left subtree -> go_through_tree subtree
+                                        Right e -> get_call_dependencies e
+
+                                in Set.unions clause_deps <> result_dependencies & rewrite_dependencies vars_defined_in_clauses
+                            )
+                        & Set.unions
+
+                get_vars_defined_in_clause :: RIR.MatchClause -> [(RIR.VariableKey, Set Dependency, Set Dependency)]
+                get_vars_defined_in_clause (RIR.MatchClause'Match _ _) = []
+                get_vars_defined_in_clause (RIR.MatchClause'Assign vk rhs) = [(vk, match_rhs_exec_deps rhs, match_rhs_call_deps rhs)]
+
+                get_clause_deps (RIR.MatchClause'Match binding _) = [NeedsCallable binding]
+                get_clause_deps (RIR.MatchClause'Assign _ rhs) = match_rhs_call_deps rhs
+
+        -- lambdas store code
+        go (RIR.Expr'Lambda _ _ param _ body) =
+            -- in order for a lambda to be callable, its body must be executable
+            -- because this lambda result can also go into a call expression, we conservatively require that it is also callable here because we cannot enforce that at the call expression
+            -- we filter out the parameter because the topological sort can't do anything about that
+            -- if the body depends on the parameter being executable or callable, that is ensured by the requirement that all call expressions' arguments must be callable
+            (get_execute_dependencies body <> get_call_dependencies body) & Set.filter (\ dep -> get_dependency_vk dep /= param)
+
+match_rhs_exec_deps :: RIR.MatchAssignRHS -> Set Dependency
+match_rhs_exec_deps (RIR.MatchAssignRHS'OtherVar vk) = [NeedsInitialized vk]
+match_rhs_exec_deps (RIR.MatchAssignRHS'TupleDestructure1 _ vk) = [NeedsInitialized vk]
+match_rhs_exec_deps (RIR.MatchAssignRHS'TupleDestructure2 _ vk) = [NeedsInitialized vk]
+match_rhs_exec_deps (RIR.MatchAssignRHS'AnonADTVariantField _ vk _) = [NeedsInitialized vk]
+
+match_rhs_call_deps :: RIR.MatchAssignRHS -> Set Dependency
+match_rhs_call_deps (RIR.MatchAssignRHS'OtherVar vk) = [NeedsCallable vk]
+match_rhs_call_deps (RIR.MatchAssignRHS'TupleDestructure1 _ vk) = [NeedsCallable vk]
+match_rhs_call_deps (RIR.MatchAssignRHS'TupleDestructure2 _ vk) = [NeedsCallable vk]
+match_rhs_call_deps (RIR.MatchAssignRHS'AnonADTVariantField _ vk _) = [NeedsCallable vk]
+
+rewrite_dependencies :: [(RIR.VariableKey, Set Dependency, Set Dependency)] -> Set Dependency -> Set Dependency
+rewrite_dependencies variables deps =
+    let bindings_false = Map.fromList $ map (\ (vk, _, _) -> (vk, False)) variables
+    in go bindings_false bindings_false deps
+    where
+        (variables_here, exec_dependencies, call_dependencies) = (Set.fromList v, Map.fromList (zip v e), Map.fromList (zip v c))
+            where
+                (v, e, c) = unzip3 variables
+
+        go exec_dependencies_included call_dependencies_included deps =
+            let (added_exec_deps, added_call_deps, deps') =
+                    deps
+                        & Set.toList
+                        & map
+                            (\ dep ->
+                                if Set.member (get_dependency_vk dep) variables_here
+                                    then case dep of
+                                             NeedsCallable dep_vk ->
+                                                 if call_dependencies_included Map.! dep_vk
+                                                     then ([], [], Set.empty)
+                                                     else ([], [dep_vk], call_dependencies Map.! dep_vk)
+
+                                             NeedsInitialized dep_vk ->
+                                                 if exec_dependencies_included Map.! dep_vk
+                                                     then ([], [], Set.empty)
+                                                     else ([dep_vk], [], exec_dependencies Map.! dep_vk)
+
+                                    else ([], [], Set.singleton dep)
+                                )
+                        & unzip3
+                deps'' = Set.unions deps'
+
+                exec_dependencies_included' = foldl' (\ m d -> Map.insert d True m) exec_dependencies_included (concat added_exec_deps)
+                call_dependencies_included' = foldl' (\ m d -> Map.insert d True m) call_dependencies_included (concat added_call_deps)
+
+            in if null (concat added_exec_deps) && null (concat added_call_deps) then deps'' else go exec_dependencies_included' call_dependencies_included' deps''
+
+sort_bindings :: Arena.Arena RIR.Variable RIR.VariableKey -> [RIR.Binding] -> Either (NonEmpty BindingsHaveLoopError, RIR.Bindings) RIR.Bindings
+sort_bindings vars bindings =
+    case find_loops bindings of
+        [] -> Right $ RIR.Bindings RIR.TopologicallySorted (topological_sort [] bindings)
+        a:more ->
+            let var_spans =
+                    Map.fromList $
+                        map
+                            (\ (RIR.Binding vk _) ->
+                                let (RIR.Variable _ _ var_sp) = Arena.get vars vk
+                                in (vk, var_sp))
+                            bindings
+            in Left (NonEmpty.map (BindingsHaveLoop var_spans) (a:|more), RIR.Bindings RIR.HasLoops bindings)
+    where
+        binding_keys_from_bindings = Set.fromList . map (\ (RIR.Binding vk _) -> vk)
+        bindings_defined_here = binding_keys_from_bindings bindings
+
+        exec_dependencies :: Map.Map RIR.VariableKey (Set Dependency)
+        exec_dependencies =
+            bindings
+                & map
+                    (\ (RIR.Binding var_key initializer) ->
+                        ( var_key
+                        , get_execute_dependencies initializer
+                            & Set.filter (\ dep -> Set.member (get_dependency_vk dep) bindings_defined_here) -- filter to only dependencies that are defined here because this topological sort cant do anything about dependencies defined elsewhere
+                        )
+                    )
+                & Map.fromList
+        call_dependencies :: Map.Map RIR.VariableKey (Set Dependency)
+        call_dependencies =
+            bindings
+                & map
+                    (\ (RIR.Binding var_key initializer) ->
+                        ( var_key
+                        , get_call_dependencies initializer
+                            & Set.filter (\ dep -> Set.member (get_dependency_vk dep) bindings_defined_here) -- same comment as above
+                        )
+                    )
+                & Map.fromList
+
+        topological_sort done [] = done
+        topological_sort done left =
+            case List.partition (exec_dependencies_satisfied (binding_keys_from_bindings done)) left of
+                ([], _) -> error "topological sort called on bindings with loops"
+                (ready, waiting) -> topological_sort (done ++ ready) waiting
+
+        exec_dependencies_satisfied executed (RIR.Binding vk _) = and $ Set.map (dependency_satisfied executed) (exec_dependencies Map.! vk)
+        dependency_satisfied executed dep = case dep of
+            NeedsInitialized depvk -> depvk `List.elem` executed -- check if dep has been executed
+
+            -- dep needs to be callable, so check if all of its call dependencies are satisfied
+            -- also check that dep has been initialized because it needs to be initialized before it is callable
+            NeedsCallable depvk -> depvk `List.elem` executed && and (Set.map (dependency_satisfied executed) (call_dependencies Map.! depvk))
+
+        find_loops bindings = trace_from_first (Set.fromList $ map (\ (RIR.Binding vk _) -> NeedsInitialized vk) bindings)
+            where
+                trace_from_first deps
+                    | Set.null deps = []
+                    | otherwise =
+                        let first = Set.findMin deps
+                            (loops, explored) = runWriter $ trace [] first
+                        in loops ++ trace_from_first (deps Set.\\ explored)
+
+                trace explored_stack current = do
+                    -- TODO: this often outputs multiple slightly different errors for what is actually the same loop
+                    tell [current]
+                    case List.elemIndex current explored_stack of
+                         Just index -> pure [reverse $ current : take (index + 1) explored_stack] -- found loop; the returned value contains the loop with its first and last elements as the same dependency
+                         _ -> do
+                            let deps = case current of
+                                    NeedsInitialized depvk -> exec_dependencies Map.! depvk
+                                    NeedsCallable depvk -> exec_dependencies Map.! depvk <> call_dependencies Map.! depvk
+                            concat <$> mapM (trace (current:explored_stack)) (toList deps)

--- a/uhf.cabal
+++ b/uhf.cabal
@@ -76,6 +76,7 @@ library
       UHF.Parts.ToBackendIR
       UHF.Parts.ToRIR
       UHF.Parts.ToRIR.PatternCheck
+      UHF.Parts.ToRIR.TopologicalSort
       UHF.Parts.ToSIR
       UHF.Parts.TSBackend
       UHF.Parts.TSBackend.TS


### PR DESCRIPTION
This moves topological sort to RIR, cleaning up ANFIR and also incidentally fixes #49. This also supersedes #16.